### PR TITLE
transaction list ui

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,1 @@
-VITE_SAMPLE_VAR=<string>
+VITE_TRANSACTIONS_KEY="expense_tracker_transactions"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# TO RUN THE APP RENAME **.env.example** to **.env**
+
 # Expense Tracker
 
 An app which lets you to track your expenses.
@@ -32,7 +34,11 @@ Open your terminal and run these commands in order:
     npm install
     ```
 
-3.  **Start the development server:**
+3. **To provide the app with environment variables:**
+
+    rename **`.env.example`** to **`.env`**
+
+4.  **Start the development server:**
 
     ```bash
     npm run dev
@@ -40,11 +46,15 @@ Open your terminal and run these commands in order:
 
     _The app should now be running at `http://localhost:3000`._
 
-4.  **To make sure Vite can successfully bundle the project for production run:**
+5.  **To make sure Vite can successfully bundle the project for production run:**
 
     ```bash
     npm run build
     ```
+
+
+
+## NOTE: Since **`.env.example`** contains no sensitive data, all values are stored in it.
 
 ## Project Structure
 
@@ -129,7 +139,7 @@ Useful if you want to check if you forgot to format a file without actually chan
 
 ## Environment Variables
 
-Define all environment variables in **.env** file.
+Define all environment variables in **`.env`** file.
 
 Any variable you want to use in the frontend must start with **VITE\_**.
 

--- a/index.html
+++ b/index.html
@@ -11,13 +11,6 @@
         <main id="app">
             <header>
                 <button id="add-transaction-btn">Add New Transaction</button>
-                <!-- <div
-                    id="view-transaction-btn"
-                    data-id="f02a0394-5159-445d-b314-96d3d4735883"
-                    style="display: inline; border: 1px solid green"
-                >
-                    View Transaction (test)
-                </div> -->
             </header>
             <article>
                 <ul id="transaction-list"></ul>

--- a/src/components/Transaction.js
+++ b/src/components/Transaction.js
@@ -15,6 +15,13 @@ export const Transaction = (data) => {
     date.textContent = data.date;
     description.textContent = data.description;
 
+    title.dataset.type = "title";
+    amount.dataset.type = "amount";
+    currency.dataset.type = "currency";
+    type.dataset.type = "type";
+    date.dataset.type = "date";
+    description.dataset.type = "description";
+
     transaction.appendChild(title);
     transaction.appendChild(amount);
     transaction.appendChild(currency);

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,20 @@
 import { openForm, closeForm, saveFormData, editFormData, deleteFormData } from "./utils/formUtils";
+import { getAll } from "./utils/storageUtils";
+import { Transaction } from "./components/Transaction";
 
-const main = () => {
+let currentActiveId = null;
+
+const renderList = () => {
+    const data = getAll(import.meta.env.VITE_TRANSACTIONS_KEY);
+    const list = document.querySelector("#transaction-list");
+    data.forEach((entry) => {
+        list.appendChild(Transaction(entry));
+    });
+};
+
+const init = () => {
+    renderList();
+
     const transactionList = document.querySelector("#transaction-list");
     const addTransactionForm = document.querySelector("#add-transaction-form");
     const viewTransactionForm = document.querySelector("#view-transaction-form");
@@ -9,34 +23,29 @@ const main = () => {
     const addNewTransaction = document.querySelector("#add-transaction-btn");
     const saveNewTransaction = document.querySelector("#add-transaction-save-btn");
     const cancelNewTransaction = document.querySelector("#add-transaction-cancel-btn");
-    addNewTransaction.addEventListener("click", () => openForm(addTransactionForm, true));
-    saveNewTransaction.addEventListener("click", () => saveFormData(addTransactionForm, true));
-    cancelNewTransaction.addEventListener("click", () => closeForm(addTransactionForm, true));
+    addNewTransaction.addEventListener("click", () => openForm(addTransactionForm));
+    saveNewTransaction.addEventListener("click", () => saveFormData(addTransactionForm));
+    cancelNewTransaction.addEventListener("click", () => closeForm(addTransactionForm));
 
     // event delegation: adds one listener to the parent instead of adding to each entry
     transactionList.addEventListener("click", (event) => {
         // existing transaction
         const transaction = event.target.closest(".transaction-entry");
         if (transaction) {
-            const id = transaction.dataset.id;
-            const saveTransaction = document.querySelector("#view-transaction-save-btn");
-            const editTransaction = document.querySelector("#view-transaction-edit-btn");
-            const deleteTransaction = document.querySelector("#view-transaction-delete-btn");
-            const cancelTransaction = document.querySelector("#view-transaction-cancel-btn");
-
-            saveTransaction.addEventListener("click", () =>
-                saveFormData(viewTransactionForm, false)
-            );
-            editTransaction.addEventListener("click", () => editFormData(viewTransactionForm));
-            deleteTransaction.addEventListener("click", () =>
-                deleteFormData(viewTransactionForm, id)
-            );
-            cancelTransaction.addEventListener("click", () =>
-                closeForm(viewTransactionForm, false)
-            );
-            openForm(viewTransactionForm, false, id);
+            currentActiveId = transaction.dataset.id;
+            openForm(viewTransactionForm, currentActiveId);
         }
     });
+    // existing transaction
+    const saveTransaction = document.querySelector("#view-transaction-save-btn");
+    const editTransaction = document.querySelector("#view-transaction-edit-btn");
+    const deleteTransaction = document.querySelector("#view-transaction-delete-btn");
+    const cancelTransaction = document.querySelector("#view-transaction-cancel-btn");
+
+    saveTransaction.addEventListener("click", () => saveFormData(viewTransactionForm));
+    editTransaction.addEventListener("click", () => editFormData(viewTransactionForm));
+    deleteTransaction.addEventListener("click", () => deleteFormData(viewTransactionForm));
+    cancelTransaction.addEventListener("click", () => closeForm(viewTransactionForm));
 };
 
-main();
+init();

--- a/src/utils/addTransaction.js
+++ b/src/utils/addTransaction.js
@@ -1,8 +1,0 @@
-import { Transaction } from "../components/Transaction";
-
-export const addTransactionToList = (data) => {
-    const list = document.querySelector("#transaction-list");
-    const transaction = Transaction(data);
-
-    list.appendChild(transaction);
-};

--- a/src/utils/uiUtils.js
+++ b/src/utils/uiUtils.js
@@ -1,0 +1,22 @@
+import { Transaction } from "../components/Transaction";
+
+export const addTransactionToList = (data) => {
+    const list = document.querySelector("#transaction-list");
+    const transaction = Transaction(data);
+
+    list.appendChild(transaction);
+};
+
+export const removeTransactionFromList = (transactionId) => {
+    const item = document.querySelector(`[data-id="${transactionId}"]`);
+    if (item) item.remove();
+};
+
+export const updateTransactionFields = (transactionId, payload) => {
+    const item = document.querySelector(`[data-id="${transactionId}"]`);
+    item.childNodes.forEach((child) => {
+        if (child.dataset.type && child.textContent !== payload[child.dataset.type]) {
+            child.textContent = payload[child.dataset.type];
+        }
+    });
+};


### PR DESCRIPTION
solves #21 

makes transaction list persistent (displayed after reloads).

loads data from localStorage on every reload and renders it.

on click the transaction form opens pre-filled with its data, ready to be edited or deleted.

the corresponding transaction `id` is provided to the form on each click, so that correct data is loaded into the form.

the UI update function updates modified fields only, so that other fields can be interacted with, no need to rerender the whole list. 